### PR TITLE
fix: AMQP fanout tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/pborman/uuid v1.2.1
 	github.com/prometheus/client_golang v1.15.1
 	github.com/rabbitmq/amqp091-go v1.8.1
-	github.com/roadrunner-server/amqp/v4 v4.4.8
+	github.com/roadrunner-server/amqp/v4 v4.4.9
 	github.com/roadrunner-server/api/v4 v4.3.2
 	github.com/roadrunner-server/app-logger/v4 v4.0.7
 	github.com/roadrunner-server/beanstalk/v4 v4.2.8
@@ -51,7 +51,7 @@ require (
 	github.com/roadrunner-server/reload/v4 v4.0.4
 	github.com/roadrunner-server/resetter/v4 v4.0.4
 	github.com/roadrunner-server/rpc/v4 v4.1.9
-	github.com/roadrunner-server/sdk/v4 v4.2.3
+	github.com/roadrunner-server/sdk/v4 v4.2.4
 	github.com/roadrunner-server/send/v4 v4.0.10
 	github.com/roadrunner-server/server/v4 v4.1.6
 	github.com/roadrunner-server/service/v4 v4.1.6

--- a/go.sum
+++ b/go.sum
@@ -969,8 +969,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qq
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/roadrunner-server/amqp/v4 v4.4.8 h1:h6xWcFWzQE0FlduotFBuy5mCB/7oBuUdnlE3CfLSiTc=
-github.com/roadrunner-server/amqp/v4 v4.4.8/go.mod h1:LPGVFhKiZmZOOYKtwRdogbJGEkWMGW3q65nmNmRxLxk=
+github.com/roadrunner-server/amqp/v4 v4.4.9 h1:mt3f4LEk5M0gtnBDLtsCe4qP+JDDjE3Bx1hWZzk65cQ=
+github.com/roadrunner-server/amqp/v4 v4.4.9/go.mod h1:LPGVFhKiZmZOOYKtwRdogbJGEkWMGW3q65nmNmRxLxk=
 github.com/roadrunner-server/api/v4 v4.3.2 h1:1zMfd2P+i9hTDFIsp9nEhCLNe+GmUrUqgnON8ZUO6Mc=
 github.com/roadrunner-server/api/v4 v4.3.2/go.mod h1:HFb1kQ/H5UkD7MBNqi4L7hXQTtc919FcO8JKPqoSVzs=
 github.com/roadrunner-server/app-logger/v4 v4.0.7 h1:T0noUxuD/jXe2JOEdB18k+FSGViHwwGsiH1A2OQRSFQ=
@@ -1033,8 +1033,8 @@ github.com/roadrunner-server/resetter/v4 v4.0.4 h1:54m5u7zegr14vAYboqa3cilAAMLa3
 github.com/roadrunner-server/resetter/v4 v4.0.4/go.mod h1:0Bfqs6AscmK6olMzlXtyYRZlfjE9Sqy9RgEC3MxieOA=
 github.com/roadrunner-server/rpc/v4 v4.1.9 h1:izbbGije6hbTJ4cp94OHzH29j4tMzawYRvSUltmG4uU=
 github.com/roadrunner-server/rpc/v4 v4.1.9/go.mod h1:MgPbJDCnQ/2khhyZ40FN756icaPSDFlUFHe/MIgGIAo=
-github.com/roadrunner-server/sdk/v4 v4.2.3 h1:vX0fyxEUnbZn8IKSpoPwkUFjHSpnU/n62T6uRnK5GPI=
-github.com/roadrunner-server/sdk/v4 v4.2.3/go.mod h1:E/YHqtsmp8mZ9QSmb4zBBp4MBS/vSX31yvQt3JQ4QdU=
+github.com/roadrunner-server/sdk/v4 v4.2.4 h1:a5SXHysBa1qNqg7fGgEcW62rykL5VNiWSia0JL9n8nU=
+github.com/roadrunner-server/sdk/v4 v4.2.4/go.mod h1:E/YHqtsmp8mZ9QSmb4zBBp4MBS/vSX31yvQt3JQ4QdU=
 github.com/roadrunner-server/send/v4 v4.0.10 h1:KJMzEimuOGvad/SX0S15ugU1EfKrUvipO9PrnoP9LfY=
 github.com/roadrunner-server/send/v4 v4.0.10/go.mod h1:+kEHd2wEMJwF5b9wj+8MZCG8Nq85cSWmvuMHPnvkBQM=
 github.com/roadrunner-server/server/v4 v4.1.6 h1:GsNbDknpAimQLqNwfrn7Zy1s8CIQw25DGfG+uI5kPmU=

--- a/php_test_files/jobs/jobs_ok_queue_name_exist.php
+++ b/php_test_files/jobs/jobs_ok_queue_name_exist.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @var Goridge\RelayInterface $relay
+ */
+
+use Spiral\Goridge;
+use Spiral\RoadRunner;
+use Spiral\Goridge\StreamRelay;
+use Spiral\RoadRunner\Jobs\Consumer;
+use Spiral\RoadRunner\Jobs\Serializer\JsonSerializer;
+use RuntimeException;
+
+ini_set('display_errors', 'stderr');
+require dirname(__DIR__) . "/vendor/autoload.php";
+
+$rr = new RoadRunner\Worker(new StreamRelay(\STDIN, \STDOUT));
+$consumer = new Consumer($rr, new JsonSerializer);
+
+while ($task = $consumer->waitTask()) {
+    try {
+        if ('unknown' === $task->getQueue()) {
+            throw new RuntimeException('Queue name was not found');
+        }
+
+        $task->complete();
+    } catch (\Throwable $e) {
+        $rr->error((string)$e);
+    }
+}

--- a/php_test_files/jobs/jobs_ok_queue_name_exist.php
+++ b/php_test_files/jobs/jobs_ok_queue_name_exist.php
@@ -9,7 +9,6 @@ use Spiral\RoadRunner;
 use Spiral\Goridge\StreamRelay;
 use Spiral\RoadRunner\Jobs\Consumer;
 use Spiral\RoadRunner\Jobs\Serializer\JsonSerializer;
-use RuntimeException;
 
 ini_set('display_errors', 'stderr');
 require dirname(__DIR__) . "/vendor/autoload.php";

--- a/plugins/jobs/amqp/configs/.rr-amqp-fanout.yaml
+++ b/plugins/jobs/amqp/configs/.rr-amqp-fanout.yaml
@@ -1,0 +1,52 @@
+version: '3'
+
+rpc:
+  listen: tcp://127.0.0.1:6001
+
+server:
+  command: "php ../../../php_test_files/jobs/jobs_ok_queue_name_exist.php"
+  relay: "pipes"
+  relay_timeout: "20s"
+
+amqp:
+  addr: amqp://guest:guest@127.0.0.1:5672/
+
+logs:
+  level: debug
+  encoding: console
+  mode: development
+
+jobs:
+  num_pollers: 1
+  pipeline_size: 100000
+  timeout: 1
+  pool:
+    num_workers: 10
+    max_jobs: 0
+    allocate_timeout: 60s
+    destroy_timeout: 1s
+
+  pipelines:
+    test-fanout-1:
+      driver: amqp
+      config:
+        prefetch: 100
+        queue: test-fanout-2
+        priority: 1
+        exchange: test-fanout
+        delete_queue_on_stop: true
+        exchange_type: fanout
+        routing_key: ''
+    test-fanout-2:
+      driver: amqp
+      config:
+        prefetch: 100
+        queue: test-fanout-2
+        priority: 1
+        exchange: test-fanout
+        delete_queue_on_stop: true
+        exchange_type: fanout
+        routing_key: ''
+
+  consume: [ "test-fanout-1", "test-fanout-2" ]
+

--- a/plugins/jobs/amqp/jobs_amqp_test.go
+++ b/plugins/jobs/amqp/jobs_amqp_test.go
@@ -118,6 +118,7 @@ func TestAMQPFanoutQueueName(t *testing.T) {
 	require.Equal(t, 2, oLogger.FilterMessageSnippet("pipeline was started").Len())
 	require.Equal(t, 2, oLogger.FilterMessageSnippet("pipeline was stopped").Len())
 	require.Equal(t, 2, oLogger.FilterMessageSnippet("job was pushed successfully").Len())
+	require.Equal(t, 2, oLogger.FilterMessageSnippet("job was processed successfully").Len())
 	require.Equal(t, 2, oLogger.FilterMessageSnippet("job processing was started").Len())
 	require.Equal(t, 2, oLogger.FilterMessageSnippet("delivery channel was closed, leaving the rabbit listener").Len())
 }


### PR DESCRIPTION
# Reason for This PR

ref: https://github.com/roadrunner-server/amqp/pull/69

## Description of Changes

This PR is made for the "fanout exchange type" RabbitMQ, when a message is sent for exchange, at consume we do not know which handler should be run, because we have no information from which RabbitMQ queue the message is consumed. And disables routing key checking for the fanout exchange type

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
